### PR TITLE
Adapt release workflow to also act as a test suite

### DIFF
--- a/.github/workflows/test_and_publish_release.yml
+++ b/.github/workflows/test_and_publish_release.yml
@@ -1,4 +1,4 @@
-name: "Create release"
+name: "Test and publish release"
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ on:
         required: true
 
 jobs:
-  create-release:
+  test-and-publish-release:
     runs-on: windows-2019
     # Only create the release if workflow is run manually. (This allows the other steps in the workflow to test PRs.)
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/test_and_publish_release.yml
+++ b/.github/workflows/test_and_publish_release.yml
@@ -15,9 +15,6 @@ jobs:
     steps:
     - name: Checkout tja2fumen (main branch)
       uses: actions/checkout@v3
-      with:
-        ref: ${{ env.MAIN_BRANCH }}
-        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/.github/workflows/test_and_publish_release.yml
+++ b/.github/workflows/test_and_publish_release.yml
@@ -13,6 +13,9 @@ on:
     branches:
       - '*'
 
+env:
+  PY_COLORS: "1"
+
 jobs:
   test-and-publish-release:
     runs-on: windows-2019

--- a/.github/workflows/test_and_publish_release.yml
+++ b/.github/workflows/test_and_publish_release.yml
@@ -13,12 +13,6 @@ jobs:
     # Only create the release if workflow is run manually. (This allows the other steps in the workflow to test PRs.)
     if: github.event_name == 'workflow_dispatch'
     steps:
-    # The GitHub Actions bot email was taken from: https://github.community/t/github-actions-bot-email-address/17204/6
-    - name: Set bot user data for commits
-      run: |
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --global user.name "GitHub Actions Bot"
-
     - name: Checkout tja2fumen (main branch)
       uses: actions/checkout@v3
       with:
@@ -32,6 +26,12 @@ jobs:
 
     - name: Install dependencies
       run: pip install toml-cli build twine pyinstaller
+
+    # The GitHub Actions bot email was taken from: https://github.community/t/github-actions-bot-email-address/17204/6
+    - name: Set bot user data for commits
+      run: |
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "GitHub Actions Bot"
 
     - name: Update pyproject.toml version (for release)
       run: |

--- a/.github/workflows/test_and_publish_release.yml
+++ b/.github/workflows/test_and_publish_release.yml
@@ -6,12 +6,16 @@ on:
       release_version:
         description: 'Release version number'
         required: true
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   test-and-publish-release:
     runs-on: windows-2019
-    # Only create the release if workflow is run manually. (This allows the other steps in the workflow to test PRs.)
-    if: github.event_name == 'workflow_dispatch'
     steps:
     - name: Checkout tja2fumen (main branch)
       uses: actions/checkout@v3
@@ -21,16 +25,29 @@ jobs:
       with:
         python-version: '3.8.x'
 
-    - name: Install dependencies
+    - name: Install test dependencies
+      run: |
+        pip install pytest
+        pip install -e .
+
+    - name: Run tests (Python API)
+      run: |
+        pytest testing --entry-point python-api
+
+    - name: Install build dependencies
       run: pip install toml-cli build twine pyinstaller
 
     # The GitHub Actions bot email was taken from: https://github.community/t/github-actions-bot-email-address/17204/6
     - name: Set bot user data for commits
+      # Only set git user data if workflow is run manually. (This allows the other steps in the workflow to test PRs.)
+      if: github.event_name == 'workflow_dispatch'
       run: |
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --global user.name "GitHub Actions Bot"
 
     - name: Update pyproject.toml version (for release)
+      # Only update the version number if workflow is run manually. (This allows the other steps in the workflow to test PRs.)
+      if: github.event_name == 'workflow_dispatch'
       run: |
         toml set --toml-path pyproject.toml project.version "${{ github.event.inputs.release_version }}"
         git add pyproject.toml
@@ -39,16 +56,32 @@ jobs:
     - name: Build wheel/sdist
       run: python -m build
 
+    - name: Uninstall editable tja2fumen and install built wheel
+      shell: bash
+      run: |
+        pip uninstall tja2fumen
+        pip install dist\*.whl
+
+    - name: Run tests (installed wheel)
+      run: pytest testing --entry-point python-cli
+
     - name: Build pyinstaller executable
       run: |
         pyinstaller src\tja2fumen\__init__.py --name tja2fumen-${{ github.event.inputs.release_version }} --add-data="src\tja2fumen\soulgauge_LUTs\*.csv;tja2fumen\soulgauge_LUTs" --onefile
 
+    - name: Run tests (installed wheel)
+      run: pytest testing --entry-point exe
+
     - name: Push release changes
+      # Only push the new tags if workflow is run manually. (This allows the other steps in the workflow to test PRs.)
+      if: github.event_name == 'workflow_dispatch'
       run: |
         git tag ${{ github.event.inputs.release_version }}
         git push --tags
 
     - uses: ncipollo/release-action@v1
+      # Only create release if workflow is run manually. (This allows the other steps in the workflow to test PRs.)
+      if: github.event_name == 'workflow_dispatch'
       name: Create release
       id: create_release
       with:
@@ -60,4 +93,6 @@ jobs:
         draft: true
 
     - name: Publish distribution to PyPI
+      # Only publish distribution if workflow is run manually. (This allows the other steps in the workflow to test PRs.)
+      if: github.event_name == 'workflow_dispatch'
       run: twine upload dist/*.whl dist/*.tar.gz --username __token__ --password ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test_and_publish_release.yml
+++ b/.github/workflows/test_and_publish_release.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Uninstall editable tja2fumen and install built wheel
       shell: bash
       run: |
-        pip uninstall tja2fumen
+        pip uninstall tja2fumen -y
         pip install dist\*.whl
 
     - name: Run tests (installed wheel)

--- a/.github/workflows/test_and_publish_release.yml
+++ b/.github/workflows/test_and_publish_release.yml
@@ -60,7 +60,7 @@ jobs:
       shell: bash
       run: |
         pip uninstall tja2fumen -y
-        pip install dist\*.whl
+        pip install dist/*.whl
 
     - name: Run tests (installed wheel)
       run: pytest testing --entry-point python-cli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,7 @@ build = ["pyinstaller"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = "-v --tb=short"
+console_output_style = "count"

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--entry-point", action="store", default="python-api")
+
+
+@pytest.fixture
+def entry_point(request):
+    return request.config.getoption("--entry-point")
+

--- a/testing/test_conversion.py
+++ b/testing/test_conversion.py
@@ -50,7 +50,7 @@ def test_converted_tja_vs_cached_fumen(id_song, tmp_path, entry_point):
     elif entry_point == "python-cli":
         os.system(f"tja2fumen {path_tja_tmp}")
     elif entry_point == "exe":
-        exe_path = os.path.join(os.path.split(path_test)[0], "dist", "tja2fumen.exe")
+        exe_path = glob.glob(os.path.join(os.path.split(path_test)[0], "dist", "*.exe"))[0]
         os.system(f"{exe_path} {path_tja_tmp}")
 
     # Fetch output fumen paths

--- a/testing/test_conversion.py
+++ b/testing/test_conversion.py
@@ -55,6 +55,7 @@ def test_converted_tja_vs_cached_fumen(id_song, tmp_path, entry_point):
 
     # Fetch output fumen paths
     paths_out = glob.glob(os.path.join(path_temp, "*.bin"))
+    assert paths_out, f"No bin files generated in {path_temp}"
 
     # Extract cached fumen files to working directory
     path_binzip = os.path.join(path_test, "data", f"{id_song}.zip")

--- a/testing/test_conversion.py
+++ b/testing/test_conversion.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import zipfile
 import re
+import glob
 
 import pytest
 
@@ -30,7 +31,7 @@ def assert_song_property(obj1, obj2, prop, measure=None, branch=None, note=None,
 
 
 @pytest.mark.parametrize('id_song', ['mikdp'])
-def test_converted_tja_vs_cached_fumen(id_song, tmp_path):
+def test_converted_tja_vs_cached_fumen(id_song, tmp_path, entry_point):
     # Define the testing directory
     path_test = os.path.dirname(os.path.realpath(__file__))
 
@@ -44,7 +45,16 @@ def test_converted_tja_vs_cached_fumen(id_song, tmp_path):
     shutil.copy(path_tja, path_tja_tmp)
 
     # Convert TJA file to fumen files
-    _, _, paths_out = convert(argv=[path_tja_tmp])
+    if entry_point == "python-api":
+        convert(argv=[path_tja_tmp])
+    elif entry_point == "python-cli":
+        os.system(f"tja2fumen {path_tja_tmp}")
+    elif entry_point == "exe":
+        exe_path = os.path.join(os.path.split(path_test)[0], "dist", "tja2fumen.exe")
+        os.system(f"{exe_path} {path_tja_tmp}")
+
+    # Fetch output fumen paths
+    paths_out = glob.glob(os.path.join(path_temp, "*.bin"))
 
     # Extract cached fumen files to working directory
     path_binzip = os.path.join(path_test, "data", f"{id_song}.zip")


### PR DESCRIPTION
Two birds with one stone! The same commands that generate the sdist/wheel/executable will also be used to test changes in PRs.

This also means that releases will be tested before anything gets uploaded to GitHub/PyPI.

Fixes #11.