### PR TITLE
Ensure that header branch bytes are correctly set for all branching cases

### DIFF
--- a/src/tja2fumen/converters.py
+++ b/src/tja2fumen/converters.py
@@ -337,6 +337,16 @@ def convert_tja_to_fumen(tja):
         fumen.header.b496_b499_branch_points_balloon = 0
         fumen.header.b500_b503_branch_points_kusudama = 0
 
+    # Alternatively, if the song has only percentage-based conditions,
+    # then set the header bytes so that only notes and balloons contribute to branching.
+    percentage_only = branch_conditions != [] and all([
+        (condition[0] != 'r')
+        for condition in branch_conditions
+    ])
+    if percentage_only:
+        fumen.header.b480_b483_branch_points_drumroll = 0
+        fumen.header.b492_b495_branch_points_drumroll_big = 0
+
     # Compute the ratio between normal and professional/master branches (just in case the note counts differ)
     if total_notes['professional']:
         fumen.header.b460_b463_normal_professional_ratio = int(65536 * (total_notes['normal'] / total_notes['professional']))

--- a/testing/test_conversion.py
+++ b/testing/test_conversion.py
@@ -79,16 +79,18 @@ def test_converted_tja_vs_cached_fumen(id_song, tmp_path, entry_point):
         assert_song_property(co_song.header, ca_song.header, 'b456_b459_normal_normal_ratio')
         assert_song_property(co_song.header, ca_song.header, 'b460_b463_normal_professional_ratio')
         assert_song_property(co_song.header, ca_song.header, 'b464_b467_normal_master_ratio')
-        # Ignore branch points for now to focus on HP bytes
-        # assert_song_property(co_song.header, ca_song.header, 'b468_b471_branch_points_good')
-        # assert_song_property(co_song.header, ca_song.header, 'b472_b475_branch_points_ok')
-        # assert_song_property(co_song.header, ca_song.header, 'b476_b479_branch_points_bad')
-        # assert_song_property(co_song.header, ca_song.header, 'b480_b483_branch_points_drumroll')
-        # assert_song_property(co_song.header, ca_song.header, 'b484_b487_branch_points_good_big')
-        # assert_song_property(co_song.header, ca_song.header, 'b488_b491_branch_points_ok_big')
-        # assert_song_property(co_song.header, ca_song.header, 'b492_b495_branch_points_drumroll_big')
-        # assert_song_property(co_song.header, ca_song.header, 'b496_b499_branch_points_balloon')
-        # assert_song_property(co_song.header, ca_song.header, 'b500_b503_branch_points_kusudama')
+        # NB: KAGEKIYO's branching condition is very unique (BIG only), which cannot be expressed in a TJA file
+        # So, skip checking the `branch_point` header values for KAGEKIYO.
+        if id_song != 'genpe':
+            assert_song_property(co_song.header, ca_song.header, 'b468_b471_branch_points_good')
+            assert_song_property(co_song.header, ca_song.header, 'b472_b475_branch_points_ok')
+            assert_song_property(co_song.header, ca_song.header, 'b476_b479_branch_points_bad')
+            assert_song_property(co_song.header, ca_song.header, 'b480_b483_branch_points_drumroll')
+            assert_song_property(co_song.header, ca_song.header, 'b484_b487_branch_points_good_big')
+            assert_song_property(co_song.header, ca_song.header, 'b488_b491_branch_points_ok_big')
+            assert_song_property(co_song.header, ca_song.header, 'b492_b495_branch_points_drumroll_big')
+            assert_song_property(co_song.header, ca_song.header, 'b496_b499_branch_points_balloon')
+            assert_song_property(co_song.header, ca_song.header, 'b500_b503_branch_points_kusudama')
         # 2. Check song metadata
         assert_song_property(co_song, ca_song, 'score_init')
         assert_song_property(co_song, ca_song, 'score_diff')


### PR DESCRIPTION
Some backstory:

- In [#45](https://github.com/vivaria/tja2fumen/pull/45), I reworked the header parsing code to make sure every header value was correctly identified.
- In [#46](https://github.com/vivaria/tja2fumen/pull/46), I changed how the "branch point" header bytes were set by checking if a song contained only drumroll branching conditions. This fixed drumroll-only songs like BATTLE NO. 1, Shoutoku Taiko, etc.

However, I missed a corner case in #46 -- songs with `#BRANCHSTART p,0,0` should still be considered "drumroll only". As well, I neglected to consider the "percentage only" songs. So, I fixed the header bytes there, too.

Then, to confirm that my changes do in fact produce correct headers, I enabled the check for `branch_points` for (most) of the songs in the test suite. The tests pass. :)

