### PR TITLE
Add proper Don/Ka types to clusters of notes

### DIFF
--- a/src/tja2fumen/__init__.py
+++ b/src/tja2fumen/__init__.py
@@ -8,7 +8,7 @@ import sys
 from typing import Sequence
 
 from tja2fumen.parsers import parse_tja
-from tja2fumen.converters import convert_tja_to_fumen
+from tja2fumen.converters import convert_tja_to_fumen, fix_dk_note_types_course
 from tja2fumen.writers import write_fumen
 from tja2fumen.constants import COURSE_IDS
 from tja2fumen.classes import TJACourse
@@ -52,6 +52,8 @@ def convert_and_write(tja_data: TJACourse,
                       single_course: bool = False) -> None:
     """Process the parsed data for a single TJA course."""
     fumen_data = convert_tja_to_fumen(tja_data)
+    # fix don/ka types
+    fix_dk_note_types_course(fumen_data)
     # Add course ID (e.g. '_x', '_x_1', '_x_2') to the output file's base name
     output_name = base_name
     if single_course:

--- a/src/tja2fumen/__init__.py
+++ b/src/tja2fumen/__init__.py
@@ -4,10 +4,11 @@ Entry points for tja2fumen.
 
 import argparse
 import os
+import shutil
 import sys
 from typing import Sequence
 
-from tja2fumen.parsers import parse_tja
+from tja2fumen.parsers import parse_tja, parse_fumen
 from tja2fumen.converters import convert_tja_to_fumen, fix_dk_note_types_course
 from tja2fumen.writers import write_fumen
 from tja2fumen.constants import COURSE_IDS
@@ -18,10 +19,14 @@ def main(argv: Sequence[str] = ()) -> None:
     """
     Main entry point for tja2fumen's command line interface.
 
-    Three steps are performed:
-       1. Parse TJA into multiple TJACourse objects. Then, for each course:
+    tja2fumen can be used in 2 ways:
+
+    - If a .tja file is provided, then three steps are performed:
+          1. Parse TJA into multiple TJACourse objects. Then, for each course:
           2. Convert TJACourse objects into FumenCourse objects.
           3. Write each FumenCourse to its own .bin file.
+    - If a .bin file is provided, then the existing .bin is repaired:
+          1. Update don/kat senote types to do-ko-don and ka-kat.
     """
     if not argv:
         argv = sys.argv[1:]
@@ -30,20 +35,27 @@ def main(argv: Sequence[str] = ()) -> None:
         description="tja2fumen"
     )
     parser.add_argument(
-        "file.tja",
-        help="Path to a Taiko no Tatsujin TJA file.",
+        "file",
+        help="Path to a Taiko no Tatsujin chart file.",
     )
     args = parser.parse_args(argv)
-    fname_tja = getattr(args, "file.tja")
-    base_name = os.path.splitext(fname_tja)[0]
+    fname = getattr(args, "file")
+    base_name = os.path.splitext(fname)[0]
 
-    # Parse lines in TJA file
-    parsed_tja = parse_tja(fname_tja)
+    if fname.endswith(".tja"):
+        print("Converitng TJA to fumen files...")
+        # Parse lines in TJA file
+        parsed_tja = parse_tja(fname)
 
-    # Convert parsed TJA courses and write each course to `.bin` files
-    for course_name, course in parsed_tja.courses.items():
-        convert_and_write(course, course_name, base_name,
-                          single_course=len(parsed_tja.courses) == 1)
+        # Convert parsed TJA courses and write each course to `.bin` files
+        for course_name, course in parsed_tja.courses.items():
+            convert_and_write(course, course_name, base_name,
+                              single_course=len(parsed_tja.courses) == 1)
+    elif fname.endswith(".bin"):
+        print("Repairing existing fumen file...")
+        repair_bin(fname)
+    else:
+        raise ValueError(f"Unexpected file extension: {fname}")
 
 
 def convert_and_write(tja_data: TJACourse,
@@ -64,6 +76,16 @@ def convert_and_write(tja_data: TJACourse,
         if len(split_name) == 2:
             output_name += f"_{split_name[1]}"  # Add "_1"/"_2" if P1/P2 chart
     write_fumen(f"{output_name}.bin", fumen_data)
+
+
+def repair_bin(fname_bin: str) -> None:
+    """Repair the don/ka types of an existing .bin file."""
+    fumen_data = parse_fumen(fname_bin)
+    # fix don/ka types
+    fix_dk_note_types_course(fumen_data)
+    # write repaired fumen
+    shutil.move(fname_bin, fname_bin+".bak")
+    write_fumen(fname_bin, fumen_data)
 
 
 # NB: This entry point is necessary for the Pyinstaller executable

--- a/src/tja2fumen/classes.py
+++ b/src/tja2fumen/classes.py
@@ -82,6 +82,7 @@ class FumenNote:
     """Contains all the byte values for a single Fumen note."""
     note_type: str = ''
     pos: float = 0.0
+    pos_abs: float = 0.0
     score_init: int = 0
     score_diff: int = 0
     padding: float = 0.0

--- a/src/tja2fumen/classes.py
+++ b/src/tja2fumen/classes.py
@@ -83,7 +83,7 @@ class FumenNote:
     note_type: str = ''
     pos: float = 0.0
     pos_abs: float = 0.0
-    diff: float = 0.0
+    diff: int = 0
     score_init: int = 0
     score_diff: int = 0
     padding: float = 0.0

--- a/src/tja2fumen/classes.py
+++ b/src/tja2fumen/classes.py
@@ -83,6 +83,7 @@ class FumenNote:
     note_type: str = ''
     pos: float = 0.0
     pos_abs: float = 0.0
+    diff: float = 0.0
     score_init: int = 0
     score_diff: int = 0
     padding: float = 0.0

--- a/src/tja2fumen/converters.py
+++ b/src/tja2fumen/converters.py
@@ -444,16 +444,16 @@ def fix_dk_note_types(dk_notes: List[FumenNote], song_bpm: float) -> None:
     # Avoid clustering any whole notes, half notes, or quarter notes
     # i.e. only cluster 8th notes, 16th notes, etc.
     measure_duration = (4 * 60_000) / song_bpm
-    half_note_duration = round(measure_duration / 2, 9)
-    diffs_under_half: List[float] = [diff for diff in diffs_unique
-                                     if diff < half_note_duration]
+    quarter_note_duration = round(measure_duration / 4, 9)
+    diffs_under_quarter: List[float] = [diff for diff in diffs_unique
+                                        if diff < quarter_note_duration]
 
     # Anything above an 8th note (12th, 16th, 24th, 36th, etc...) should be
     # clustered together as a single stream
     diffs_to_cluster: List[List[float]] = []
     diffs_under_8th: List[float] = []
     eighth_note_duration = round(measure_duration / 8, 9)
-    for diff in diffs_under_half:
+    for diff in diffs_under_quarter:
         if diff < eighth_note_duration:
             diffs_under_8th.append(diff)
         else:

--- a/src/tja2fumen/converters.py
+++ b/src/tja2fumen/converters.py
@@ -472,10 +472,11 @@ def fix_dk_note_types(dk_notes: List[FumenNote], song_bpm: float) -> None:
                        for cluster in semi_clustered]
 
     # In each cluster, replace dons/kas with their alternate versions
-    replace_alternate_don_kas(clustered_notes)
+    replace_alternate_don_kas(clustered_notes, eighth_note_duration)
 
 
-def replace_alternate_don_kas(note_clusters: List[List[FumenNote]]) -> None:
+def replace_alternate_don_kas(note_clusters: List[List[FumenNote]],
+                              eighth_note_duration: float) -> None:
     """
     Replace Don/Ka notes with alternate versions (Don2, Don3, Ka2) based on
     positions within a cluster of notes.
@@ -496,7 +497,16 @@ def replace_alternate_don_kas(note_clusters: List[List[FumenNote]]) -> None:
 
         # Replace the last note in a cluster with the ending Don/Kat
         # In other words, remove the '2' from the last note.
-        cluster[-1].note_type = cluster[-1].note_type[:-1]
+        # However, there's one exception: Groups of 4 notes, faster than 8th
+        is_fast_cluster_of_4 = (len(cluster) == 4 and
+                                all(note.diff < eighth_note_duration
+                                    for note in cluster[:-1]))
+        if is_fast_cluster_of_4:
+            # Leave last note as Don2/Ka2
+            pass
+        else:
+            # Replace last Don2/Ka2 with Don/Ka
+            cluster[-1].note_type = cluster[-1].note_type[:-1]
 
 
 def cluster_notes(item_list: List[Union[FumenNote, List[FumenNote]]],

--- a/src/tja2fumen/converters.py
+++ b/src/tja2fumen/converters.py
@@ -454,7 +454,7 @@ def replace_alternate_don_kas(note_clusters):
         # in odd-length all-don runs (DDD: Do-ko-don, DDDDD: Do-ko-do-ko-don)
         all_dons = all([note.note_type.startswith("Don") for note in cluster])
         for i, note in enumerate(cluster):
-            if all_dons and (len(cluster) % 2 == 1) and (i % 2 == 0):
+            if all_dons and (len(cluster) % 2 == 1) and (i % 2 == 1):
                 note.note_type = "Don3"
 
         # Replace the last note in a cluster with the ending Don/Kat

--- a/src/tja2fumen/converters.py
+++ b/src/tja2fumen/converters.py
@@ -319,7 +319,8 @@ def convert_tja_to_fumen(tja: TJACourse) -> FumenCourse:
                 # we can initialize a note and handle general note metadata.
                 note = FumenNote()
                 note.pos = note_pos
-                note.pos_abs = measure_fumen.offset_start + note_pos
+                note.pos_abs = (measure_fumen.offset_start + note_pos +
+                                (4 * 60_000 / measure_fumen.bpm))
                 note.note_type = note_tja.value
                 note.score_init = tja.score_init
                 note.score_diff = tja.score_diff

--- a/src/tja2fumen/converters.py
+++ b/src/tja2fumen/converters.py
@@ -430,6 +430,9 @@ def fix_dk_note_types(dk_notes: List[FumenNote]) -> None:
 
     NB: Modifies FumenNote objects in-place
     """
+    # Sort the notes by their absolute positions to account for BPMCHANGE
+    dk_notes = sorted(dk_notes, key=lambda note: note.pos_abs)
+
     # Get the differences between each note and the previous one
     for (note_1, note_2) in zip(dk_notes, dk_notes[1:]):
         note_1.diff = round(note_2.pos_abs - note_1.pos_abs, 9)

--- a/src/tja2fumen/parsers.py
+++ b/src/tja2fumen/parsers.py
@@ -156,6 +156,12 @@ def split_tja_lines_into_courses(lines: List[str]) -> TJASong:
                         if not v.data]:
         del parsed_tja.courses[course_name]
 
+    # Recreate dict with consistent insertion order
+    parsed_tja.courses = {
+        key: parsed_tja.courses[key] for key
+        in sorted(parsed_tja.courses.keys())
+    }
+
     return parsed_tja
 
 


### PR DESCRIPTION
This should match most fumens. Some exceptional cases I've seen:

- [x] ~In official fumens, even-numbered clusters of 4 notes will sometimes be ドドドド or カカカカ. Right now, my converter will always use ドドドドン or カカカカッ, since I don't really understand the rules behind it.~ Fixed: Now, all 16th notes and above in groups of 4 will no longer use the don/kat ending character.
- [X] ~In official fumens, sometimes isolated notes will be grouped together, but sometimes they will be treated as single clusters of 1. Right now, my converter will always try to cluster isolated notes.~ Fixed: Only 4th/8th/16th/etc. notes will be clustered. Whole/half notes will not be clustered.
- [x] ~Right now, my logic always treats big notes as their own cluster. But, sometimes you get a cluster like `ddddD`, and right now my converter treats this as (ドドドドン) + big DON instead of do-ko-do-ko-DON.~ Fixed: Now big notes are included in clusters.
- [x] ~For high-level Oni songs with complex groups of dense notes (e.g. (12th/16th/24th) notes mixed with (16th/34th/32nd) notes), official fumens seem to group them together even though they technically have different timings. Right now, my converter will group the 32nd notes, but treat the 16th notes as their own separate group.~ Fixed: Now anything above an 8th note will be clustered together.
- [X] Songs with BPM gimmicks. e.g. the TJA has low base BPM, but then everything is doubled/tripled except for one section. I can't remember which songs have this? Something like RNG Cinderella?
    - Maybe solved by https://github.com/vivaria/tja2fumen/pull/64/commits/1f640c1aa1fb436fe6edf421e077fdb2a41aaf00?

Fixes #41.