### PR TITLE
Allow `tja2fumen` to be run on folders to allow fixing timing windows on all .bin files

### DIFF
--- a/src/tja2fumen/__init__.py
+++ b/src/tja2fumen/__init__.py
@@ -127,7 +127,19 @@ def convert_and_write(tja_data: TJACourse,
 def repair_bin(fname_bin: str) -> None:
     """Repair the don/ka types of an existing .bin file."""
     fumen_data = parse_fumen(fname_bin)
+    # fix timing windows
+    for course, course_id in COURSE_IDS.items():
+        if any([fname_bin.endswith(f"_{i}.bin")
+                for i in [course_id, f"{course_id}_1", f"{course_id}_2"]]):
+            print(f"  - Setting {course} timing windows...")
+            fumen_data.header.set_timing_windows(difficulty=course)
+            break
+    else:
+        print(f"  - Can't infer difficulty {list(COURSE_IDS.values())} from "
+              f"filename. Skipping timing window fix...")
+
     # fix don/ka types
+    print("  - Fixing don/ka note types (do/ko/don, ka/kat)...")
     fix_dk_note_types_course(fumen_data)
     # write repaired fumen
     shutil.move(fname_bin, fname_bin+".bak")

--- a/src/tja2fumen/__init__.py
+++ b/src/tja2fumen/__init__.py
@@ -25,7 +25,7 @@ def main(argv: Sequence[str] = ()) -> None:
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="""
-tja2fumen is a tool to 
+tja2fumen is a tool to
 
 tja2fumen can be used in 3 ways:
 - If a .tja file is provided, then three steps are performed:

--- a/src/tja2fumen/__init__.py
+++ b/src/tja2fumen/__init__.py
@@ -6,7 +6,7 @@ import argparse
 import os
 import shutil
 import sys
-from typing import Sequence
+from typing import Sequence, Tuple, List
 
 from tja2fumen.parsers import parse_tja, parse_fumen
 from tja2fumen.converters import convert_tja_to_fumen, fix_dk_note_types_course
@@ -72,7 +72,7 @@ processed according to the above logic. (Confirmation is required for safety.)
         process_file(file)
 
 
-def parse_files(directory: str) -> (Sequence[str], Sequence[str]):
+def parse_files(directory: str) -> Tuple[List[str], List[str]]:
     """Find all .tja or .bin files within a directory."""
     tja_files, bin_files = [], []
     for root, _, files in os.walk(directory):
@@ -88,7 +88,7 @@ def parse_files(directory: str) -> (Sequence[str], Sequence[str]):
     return tja_files, bin_files
 
 
-def process_file(fname: str):
+def process_file(fname: str) -> None:
     """Process a single file path (TJA or BIN)."""
     if fname.endswith(".bin"):
         print(f"Repairing {fname}")


### PR DESCRIPTION
This saves the need for users running an extra script to call tja2fumen once per file

This is especially important for the fix in #74.

Sample usage:

```console
$ tja2fumen testing/data/custom_tjas/
Folder passed to tja2fumen. Looking for files in testing/data/custom_tjas/...

Skipping 'song_190378062.bin' because it starts with 'song_' (probably an aud
io file, not a chart file).
Skipping 'song_234351376.bin' because it starts with 'song_' (probably an aud
io file, not a chart file).

The following TJA files will be CONVERTED:
  - testing/data/custom_tjas/Patapon_3\Patapon_3_Acchichichis_Theme.tja      
  - testing/data/custom_tjas/September\September.tja

The following BIN files will be REPAIRED:
  - testing/data/custom_tjas/Patapon_3\Patapon_3_Acchichichis_Theme.bin      
  - testing/data/custom_tjas/Patapon_3\Patapon_3_... [GENERATED]\190378062_m.
bin
  - testing/data/custom_tjas/September\September_e.bin
  - testing/data/custom_tjas/September\September_e_1.bin
  - testing/data/custom_tjas/September\September_e_2.bin
  - testing/data/custom_tjas/September\September_h.bin
  - testing/data/custom_tjas/September\September_h_1.bin
  - testing/data/custom_tjas/September\September_h_2.bin
  - testing/data/custom_tjas/September\September_m.bin
  - testing/data/custom_tjas/September\September_n.bin
  - testing/data/custom_tjas/September\September_n_1.bin
  - testing/data/custom_tjas/September\September_n_2.bin
  - testing/data/custom_tjas/September\September_x.bin
  - testing/data/custom_tjas/September\September_x_1.bin
  - testing/data/custom_tjas/September\September_x_2.bin
  - testing/data/custom_tjas/September\September [GENERATED]\234351376_e.bin 
  - testing/data/custom_tjas/September\September [GENERATED]\234351376_h.bin 
  - testing/data/custom_tjas/September\September [GENERATED]\234351376_m.bin 
  - testing/data/custom_tjas/September\September [GENERATED]\234351376_n.bin 
  - testing/data/custom_tjas/September\September [GENERATED]\234351376_x.bin 

Do you wish to continue? [y/n]y

Converting testing/data/custom_tjas/Patapon_3\Patapon_3_Acchichichis_Theme.tj
a
Converting testing/data/custom_tjas/September\September.tja
Repairing testing/data/custom_tjas/Patapon_3\Patapon_3_Acchichichis_Theme.bin
  - Can't infer difficulty ['e', 'n', 'h', 'm', 'x'] from filename. Skipping 
timing window fix...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/Patapon_3\Patapon_3_... [GENERATED]\190378
062_m.bin
  - Setting Oni timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September_e.bin
  - Setting Easy timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September_e_1.bin
  - Setting Easy timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September_e_2.bin
  - Setting Easy timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September_h.bin
  - Setting Hard timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September_h_1.bin
  - Setting Hard timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September_h_2.bin
  - Setting Hard timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September_m.bin
  - Setting Oni timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September_n.bin
  - Setting Normal timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September_n_1.bin
  - Setting Normal timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September_n_2.bin
  - Setting Normal timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September_x.bin
  - Setting Ura timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September_x_1.bin
  - Setting Ura timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September_x_2.bin
  - Setting Ura timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September [GENERATED]\234351376_
e.bin
  - Setting Easy timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September [GENERATED]\234351376_
h.bin
  - Setting Hard timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September [GENERATED]\234351376_
m.bin
  - Setting Oni timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September [GENERATED]\234351376_
n.bin
  - Setting Normal timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
Repairing testing/data/custom_tjas/September\September [GENERATED]\234351376_
x.bin
  - Setting Ura timing windows...
  - Fixing don/ka note types (do/ko/don, ka/kat)...
```

Fixes #72.